### PR TITLE
Add customizable glass fallback effects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "UniversalGlass",
     platforms: [
         .iOS(.v17),
+        .visionOS(.v1),
         .macOS(.v13),
         .watchOS(.v10),
         .tvOS(.v17)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 </div>
 
 <p align="center">
-  <a href="https://developer.apple.com/ios/"><img src="https://badgen.net/badge/iOS/17+/purple" alt="iOS 17+"></a>
+  <a href="https://developer.apple.com/ios/"><img src="https://badgen.net/badge/iOS/17+/blue" alt="iOS 17+"></a>
+  <a href="https://developer.apple.com/visionOS/"><img src="https://badgen.net/badge/visionOS/1+/blue" alt="visionOS 1+"></a>
   <a href="https://www.apple.com/macos/"><img src="https://badgen.net/badge/macOS/13+/blue" alt="macOS 13+"></a>
   <a href="https://developer.apple.com/tvos/"><img src="https://badgen.net/badge/tvOS/17+/blue" alt="tvOS 17+"></a>
   <a href="https://developer.apple.com/watchos/"><img src="https://badgen.net/badge/watchOS/10+/blue" alt="watchOS 10+"></a>

--- a/Sources/UniversalGlass/ButtonStyles/UniversalGlassPrimitiveButtonStyle.swift
+++ b/Sources/UniversalGlass/ButtonStyles/UniversalGlassPrimitiveButtonStyle.swift
@@ -20,11 +20,15 @@ public struct UniversalGlassButtonStyle: PrimitiveButtonStyle {
     @ViewBuilder
     private func resolvedBody(configuration: Configuration) -> some View {
         if shouldUseGlass {
-            if #available(iOS 26.0, macOS 26.0, *) {
+            #if !os(visionOS)
+            if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
                 GlassButtonStyle().makeBody(configuration: configuration)
             } else {
                 fallbackBody(configuration: configuration)
             }
+            #else
+            fallbackBody(configuration: configuration)
+            #endif
         } else {
             fallbackBody(configuration: configuration)
         }
@@ -61,11 +65,15 @@ public struct UniversalGlassProminentButtonStyle: PrimitiveButtonStyle {
     @ViewBuilder
     private func resolvedBody(configuration: Configuration) -> some View {
         if shouldUseGlass {
-            if #available(iOS 26.0, macOS 26.0, *) {
+            #if !os(visionOS)
+            if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
                 GlassProminentButtonStyle().makeBody(configuration: configuration)
             } else {
                 fallbackBody(configuration: configuration)
             }
+            #else
+            fallbackBody(configuration: configuration)
+            #endif
         } else {
             fallbackBody(configuration: configuration)
         }

--- a/Sources/UniversalGlass/GlassEffects/UniversalGlassConfiguration.swift
+++ b/Sources/UniversalGlass/GlassEffects/UniversalGlassConfiguration.swift
@@ -60,10 +60,12 @@ public struct UniversalGlassConfiguration {
     let fallbackShadow: UniversalGlassShadow
     private let _liquidGlass: Any?
 
-    @available(iOS 26.0, macOS 26.0, *)
+    #if !os(visionOS)
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *)
     public var liquidGlass: Glass? {
         _liquidGlass as? Glass
     }
+    #endif
 
     private init(
         fallbackMaterial: Material?,
@@ -79,7 +81,8 @@ public struct UniversalGlassConfiguration {
     
     /// Regular liquid glass effect with regular material fallback.
     nonisolated(unsafe) public static let regular: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return UniversalGlassConfiguration(
                 fallbackMaterial: .regularMaterial,
                 fallbackTint: nil,
@@ -88,11 +91,15 @@ public struct UniversalGlassConfiguration {
         } else {
             return UniversalGlassConfiguration(fallbackMaterial: .regularMaterial)
         }
+        #else
+        return UniversalGlassConfiguration(fallbackMaterial: .regularMaterial)
+        #endif
     }()
     
     /// Thick liquid glass effect with thick material fallback and subtle background tint.
     nonisolated(unsafe) public static let thick: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             let tint = systemBackgroundTint(opacity: 0.4)
             let tintedGlass: Any = Glass.regular.tint(tint)
             return UniversalGlassConfiguration(
@@ -101,15 +108,17 @@ public struct UniversalGlassConfiguration {
                 liquidGlass: tintedGlass
             )
         }
+        #endif
         return UniversalGlassConfiguration(
             fallbackMaterial: .thickMaterial,
             fallbackTint: nil
         )
     }()
-    
+
     /// Ultra thick liquid glass effect with ultra thick material fallback and stronger tinting.
     nonisolated(unsafe) public static let ultraThick: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             let tint = systemBackgroundTint(opacity: 0.7)
             let tintedGlass: Any = Glass.regular.tint(tint)
             return UniversalGlassConfiguration(
@@ -118,15 +127,17 @@ public struct UniversalGlassConfiguration {
                 liquidGlass: tintedGlass
             )
         }
+        #endif
         return UniversalGlassConfiguration(
             fallbackMaterial: .ultraThickMaterial,
             fallbackTint: nil
         )
     }()
-    
+
     /// Thin liquid glass effect with thin material fallback and a faint background tint.
     nonisolated(unsafe) public static let thin: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             let tint = systemBackgroundTint(opacity: 0.4)
             let tintedGlass: Any = Glass.clear.tint(tint)
             return UniversalGlassConfiguration(
@@ -135,15 +146,17 @@ public struct UniversalGlassConfiguration {
                 liquidGlass: tintedGlass
             )
         }
+        #endif
         return UniversalGlassConfiguration(
             fallbackMaterial: .thinMaterial,
             fallbackTint: nil
         )
     }()
-    
+
     /// Ultra thin liquid glass effect with ultra thin material fallback using clear glass.
     nonisolated(unsafe) public static let ultraThin: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return UniversalGlassConfiguration(
                 fallbackMaterial: .ultraThinMaterial,
                 fallbackTint: nil,
@@ -152,11 +165,15 @@ public struct UniversalGlassConfiguration {
         } else {
             return UniversalGlassConfiguration(fallbackMaterial: .ultraThinMaterial)
         }
+        #else
+        return UniversalGlassConfiguration(fallbackMaterial: .ultraThinMaterial)
+        #endif
     }()
-    
+
     /// Clear liquid glass effect with ultra thin material fallback.
     nonisolated(unsafe) public static let clear: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return UniversalGlassConfiguration(
                 fallbackMaterial: .ultraThinMaterial,
                 fallbackTint: nil,
@@ -165,11 +182,15 @@ public struct UniversalGlassConfiguration {
         } else {
             return UniversalGlassConfiguration(fallbackMaterial: .ultraThinMaterial)
         }
+        #else
+        return UniversalGlassConfiguration(fallbackMaterial: .ultraThinMaterial)
+        #endif
     }()
 
     /// Identity configuration with no glass effect or material.
     nonisolated(unsafe) public static let identity: UniversalGlassConfiguration = {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             return UniversalGlassConfiguration(
                 fallbackMaterial: nil,
                 fallbackTint: nil,
@@ -178,12 +199,16 @@ public struct UniversalGlassConfiguration {
         } else {
             return UniversalGlassConfiguration(fallbackMaterial: nil)
         }
+        #else
+        return UniversalGlassConfiguration(fallbackMaterial: nil)
+        #endif
     }()
 
     /// Creates a tinted liquid glass effect with the specified color.
     /// Falls back to regular material on older versions.
     public func tint(_ color: Color) -> UniversalGlassConfiguration {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             if let existingGlass = liquidGlass {
                 let tintedGlass: Any = existingGlass.tint(color)
                 return UniversalGlassConfiguration(
@@ -201,19 +226,20 @@ public struct UniversalGlassConfiguration {
                     liquidGlass: tintedGlass
                 )
             }
-        } else {
-            return UniversalGlassConfiguration(
-                fallbackMaterial: fallbackMaterial,
-                fallbackTint: color,
-                fallbackShadow: fallbackShadow
-            )
         }
+        #endif
+        return UniversalGlassConfiguration(
+            fallbackMaterial: fallbackMaterial,
+            fallbackTint: color,
+            fallbackShadow: fallbackShadow
+        )
     }
 
     /// Creates an interactive liquid glass effect.
     /// Falls back to the same material on older versions.
     public func interactive(_ isInteractive: Bool = true) -> UniversalGlassConfiguration {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             if let existingGlass = liquidGlass {
                 let interactiveGlass: Any = existingGlass.interactive(isInteractive)
                 return UniversalGlassConfiguration(
@@ -231,13 +257,13 @@ public struct UniversalGlassConfiguration {
                     liquidGlass: interactiveGlass
                 )
             }
-        } else {
-            return UniversalGlassConfiguration(
-                fallbackMaterial: fallbackMaterial,
-                fallbackTint: fallbackTint,
-                fallbackShadow: fallbackShadow
-            )
         }
+        #endif
+        return UniversalGlassConfiguration(
+            fallbackMaterial: fallbackMaterial,
+            fallbackTint: fallbackTint,
+            fallbackShadow: fallbackShadow
+        )
     }
 
     /// Customizes the fallback material and tint used on older OS versions.

--- a/Sources/UniversalGlass/GlassEffects/UniversalGlassConfiguration.swift
+++ b/Sources/UniversalGlass/GlassEffects/UniversalGlassConfiguration.swift
@@ -22,12 +22,42 @@ private extension UniversalGlassConfiguration {
 import AppKit
 #endif
 
+// MARK: - Universal Glass Shadow
+
+/// Defines shadow properties for glass effect fallbacks.
+public struct UniversalGlassShadow: Equatable {
+    public let color: Color
+    public let radius: CGFloat
+
+    /// Creates a custom shadow configuration.
+    /// - Parameters:
+    ///   - color: The shadow color.
+    ///   - radius: The shadow blur radius.
+    public init(color: Color, radius: CGFloat) {
+        self.color = color
+        self.radius = radius
+    }
+
+    /// Default shadow with subtle black blur.
+    nonisolated(unsafe) public static let `default` = UniversalGlassShadow(
+        color: .black.opacity(0.04),
+        radius: 8
+    )
+
+    /// No shadow.
+    nonisolated(unsafe) public static let none = UniversalGlassShadow(
+        color: .clear,
+        radius: 0
+    )
+}
+
 // MARK: - Universal Glass Configuration
 
 /// A configuration type that provides liquid glass effects on iOS 26+ and material fallbacks on older versions.
 public struct UniversalGlassConfiguration {
     let fallbackMaterial: Material?
     let fallbackTint: Color?
+    let fallbackShadow: UniversalGlassShadow
     private let _liquidGlass: Any?
 
     @available(iOS 26.0, macOS 26.0, *)
@@ -38,10 +68,12 @@ public struct UniversalGlassConfiguration {
     private init(
         fallbackMaterial: Material?,
         fallbackTint: Color? = nil,
+        fallbackShadow: UniversalGlassShadow = .default,
         liquidGlass: Any? = nil
     ) {
         self.fallbackMaterial = fallbackMaterial
         self.fallbackTint = fallbackTint
+        self.fallbackShadow = fallbackShadow
         self._liquidGlass = liquidGlass
     }
     
@@ -157,6 +189,7 @@ public struct UniversalGlassConfiguration {
                 return UniversalGlassConfiguration(
                     fallbackMaterial: fallbackMaterial,
                     fallbackTint: color,
+                    fallbackShadow: fallbackShadow,
                     liquidGlass: tintedGlass
                 )
             } else {
@@ -164,17 +197,19 @@ public struct UniversalGlassConfiguration {
                 return UniversalGlassConfiguration(
                     fallbackMaterial: fallbackMaterial,
                     fallbackTint: color,
+                    fallbackShadow: fallbackShadow,
                     liquidGlass: tintedGlass
                 )
             }
         } else {
             return UniversalGlassConfiguration(
                 fallbackMaterial: fallbackMaterial,
-                fallbackTint: color
+                fallbackTint: color,
+                fallbackShadow: fallbackShadow
             )
         }
     }
-    
+
     /// Creates an interactive liquid glass effect.
     /// Falls back to the same material on older versions.
     public func interactive(_ isInteractive: Bool = true) -> UniversalGlassConfiguration {
@@ -184,6 +219,7 @@ public struct UniversalGlassConfiguration {
                 return UniversalGlassConfiguration(
                     fallbackMaterial: fallbackMaterial,
                     fallbackTint: fallbackTint,
+                    fallbackShadow: fallbackShadow,
                     liquidGlass: interactiveGlass
                 )
             } else {
@@ -191,15 +227,43 @@ public struct UniversalGlassConfiguration {
                 return UniversalGlassConfiguration(
                     fallbackMaterial: fallbackMaterial,
                     fallbackTint: fallbackTint,
+                    fallbackShadow: fallbackShadow,
                     liquidGlass: interactiveGlass
                 )
             }
         } else {
             return UniversalGlassConfiguration(
                 fallbackMaterial: fallbackMaterial,
-                fallbackTint: fallbackTint
+                fallbackTint: fallbackTint,
+                fallbackShadow: fallbackShadow
             )
         }
+    }
+
+    /// Customizes the fallback material and tint used on older OS versions.
+    /// - Parameters:
+    ///   - material: The Material to use when liquid glass is unavailable. Pass `nil` to remove material fallback.
+    ///   - tint: Optional color tint to apply to the fallback. Pass `nil` to remove tint.
+    /// - Returns: A new configuration with the specified fallback settings.
+    public func fallback(material: Material?, tint: Color? = nil) -> UniversalGlassConfiguration {
+        return UniversalGlassConfiguration(
+            fallbackMaterial: material,
+            fallbackTint: tint,
+            fallbackShadow: fallbackShadow,
+            liquidGlass: _liquidGlass
+        )
+    }
+
+    /// Customizes the shadow applied to the fallback material on older OS versions.
+    /// - Parameter shadow: The shadow configuration to use for the fallback.
+    /// - Returns: A new configuration with the specified shadow settings.
+    public func shadow(_ shadow: UniversalGlassShadow) -> UniversalGlassConfiguration {
+        return UniversalGlassConfiguration(
+            fallbackMaterial: fallbackMaterial,
+            fallbackTint: fallbackTint,
+            fallbackShadow: shadow,
+            liquidGlass: _liquidGlass
+        )
     }
 }
 

--- a/Sources/UniversalGlass/GlassEffects/UniversalGlassConfiguration.swift
+++ b/Sources/UniversalGlass/GlassEffects/UniversalGlassConfiguration.swift
@@ -8,7 +8,7 @@ import UIKit
 private extension UniversalGlassConfiguration {
     static func systemBackgroundTint(opacity: Double) -> Color {
         let base: Color
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
         base = Color(UIColor.systemBackground)
 #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
         base = Color(NSColor.windowBackgroundColor)

--- a/Sources/UniversalGlass/GlassEffects/UniversalGlassEffect.swift
+++ b/Sources/UniversalGlass/GlassEffects/UniversalGlassEffect.swift
@@ -187,7 +187,8 @@ private struct _UniversalGlassEffectView<Content: View>: View {
     var body: some View {
         let effectiveRendering = environmentRendering ?? rendering
 
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             switch effectiveRendering {
             case .material:
                 content.modifier(
@@ -223,6 +224,17 @@ private struct _UniversalGlassEffectView<Content: View>: View {
                 )
             )
         }
+        #else
+        // visionOS doesn't have Glass APIs, always use Material fallback
+        content.modifier(
+            UniversalGlassEffectModifier(
+                fallbackMaterial: fallbackMaterial,
+                glassConfiguration: glassConfiguration,
+                shape: shape,
+                rendering: effectiveRendering
+            )
+        )
+        #endif
     }
 }
 

--- a/Sources/UniversalGlass/UniversalGlassContainers.swift
+++ b/Sources/UniversalGlass/UniversalGlassContainers.swift
@@ -300,6 +300,7 @@ private struct GlassEffectUnionBackground: View {
         let shape = anchor.shape ?? AnyGlassShape(Capsule())
         let material = anchor.glass?.fallbackMaterial ?? anchor.fallbackMaterial
         let tint = anchor.glass?.fallbackTint ?? anchor.fallbackTint
+        let shadow = anchor.glass?.fallbackShadow ?? .default
 
         if let material = material {
             return AnyView(
@@ -310,7 +311,7 @@ private struct GlassEffectUnionBackground: View {
                     if #available(iOS 15.0, macOS 13.0, *) {
                         shape
                             .fill(material)
-                            .shadow(color: Color.black.opacity(0.04), radius: 8)
+                            .shadow(color: shadow.color, radius: shadow.radius)
                     } else {
                         shape.fill(material)
                     }

--- a/Sources/UniversalGlass/UniversalGlassContainers.swift
+++ b/Sources/UniversalGlass/UniversalGlassContainers.swift
@@ -9,7 +9,8 @@ public func UniversalGlassEffectContainer<Content: View>(
     rendering: UniversalGlassRendering = .automatic,
     @ViewBuilder content: @escaping () -> Content
 ) -> some View {
-    if #available(iOS 26.0, macOS 26.0, *) {
+    #if !os(visionOS)
+    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
         switch rendering {
         case .material:
             FallbackGlassEffectContainerRenderer(
@@ -27,6 +28,14 @@ public func UniversalGlassEffectContainer<Content: View>(
             content: content
         )
     }
+    #else
+    // visionOS doesn't have GlassEffectContainer, always use fallback
+    FallbackGlassEffectContainerRenderer(
+        spacing: spacing,
+        rendering: rendering,
+        content: content
+    )
+    #endif
 }
 
 // MARK: - Glass Effect Morphing Helpers
@@ -40,7 +49,8 @@ public extension View {
         namespace: Namespace.ID,
         rendering: UniversalGlassRendering = .automatic
     ) -> some View {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             switch rendering {
             case .material:
                 self
@@ -58,6 +68,13 @@ public extension View {
                     context.union = GlassEffectUnion(id: AnyHashable(id), namespace: namespace)
                 }
         }
+        #else
+        // visionOS doesn't have glassEffectUnion, always use fallback context
+        self
+            .transformEnvironment(\.glassEffectParticipantContext) { context in
+                context.union = GlassEffectUnion(id: AnyHashable(id), namespace: namespace)
+            }
+        #endif
     }
     
     /// Applies a glass effect ID for morphing transitions with backward compatibility
@@ -67,7 +84,8 @@ public extension View {
         in namespace: Namespace.ID,
         rendering: UniversalGlassRendering = .automatic
     ) -> some View {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             switch rendering {
             case .material:
                 self.transformEnvironment(\.glassEffectParticipantContext) { context in
@@ -85,6 +103,13 @@ public extension View {
                 context.union = GlassEffectUnion(id: AnyHashable(id), namespace: namespace)
             }
         }
+        #else
+        // visionOS doesn't have glassEffectID, always use fallback context
+        self.transformEnvironment(\.glassEffectParticipantContext) { context in
+            context.effectID = AnyHashable(id)
+            context.union = GlassEffectUnion(id: AnyHashable(id), namespace: namespace)
+        }
+        #endif
     }
 }
 
@@ -103,12 +128,13 @@ public extension View {
     func universalGlassEffectTransition(
         _ transition: UniversalGlassEffectTransition
     ) -> some View {
-        if #available(iOS 26.0, macOS 26.0, *) {
+        #if !os(visionOS)
+        if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
             switch transition {
             case .materialize:
                 self.glassEffectTransition(.materialize)
             case .matchedGeometry:
-                if #available(iOS 26.1, macOS 26.1, *) {
+                if #available(iOS 26.1, macOS 26.1, tvOS 26.1, watchOS 26.1, *) {
                     self.glassEffectTransition(.matchedGeometry)
                 } else {
                     self
@@ -126,6 +152,17 @@ public extension View {
                 self
             }
         }
+        #else
+        // visionOS doesn't have glassEffectTransition, always use material transitions
+        switch transition {
+        case .materialize:
+            self.transition(.universalGlassMaterialBlur)
+        case .matchedGeometry:
+            self.transition(.universalGlassMaterialBlur)
+        case .identity:
+            self
+        }
+        #endif
     }
 }
 

--- a/Sources/UniversalGlassBackports/BackportGlassButtonStyles.swift
+++ b/Sources/UniversalGlassBackports/BackportGlassButtonStyles.swift
@@ -8,7 +8,8 @@ import UniversalGlass
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable, message: "Use UniversalGlassButtonStyle directly - Glass button styles are not available on visionOS")
 public extension PrimitiveButtonStyle where Self == UniversalGlassButtonStyle {
     static var glass: UniversalGlassButtonStyle {
         UniversalGlassButtonStyle()
@@ -19,7 +20,8 @@ public extension PrimitiveButtonStyle where Self == UniversalGlassButtonStyle {
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable, message: "Use UniversalGlassProminentButtonStyle directly - Glass button styles are not available on visionOS")
 public extension PrimitiveButtonStyle where Self == UniversalGlassProminentButtonStyle {
     static var glassProminent: UniversalGlassProminentButtonStyle {
         UniversalGlassProminentButtonStyle()

--- a/Sources/UniversalGlassBackports/BackportGlassContainers.swift
+++ b/Sources/UniversalGlassBackports/BackportGlassContainers.swift
@@ -7,7 +7,8 @@ import UniversalGlass
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable, message: "Use UniversalGlassEffectContainer instead - GlassEffectContainer is not available on visionOS")
 @MainActor @ViewBuilder
 public func GlassEffectContainer<Content: View>(
     spacing: CGFloat? = nil,
@@ -20,7 +21,8 @@ public func GlassEffectContainer<Content: View>(
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable, message: "Use universalGlassEffectUnion and universalGlassEffectID instead - Glass effect morphing APIs are not available on visionOS")
 public extension View {
     @ViewBuilder
     func glassEffectUnion<ID: Hashable & Sendable>(
@@ -45,7 +47,8 @@ public extension View {
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable)
 public enum GlassEffectTransitionBackport: Sendable {
     case materialize
     case matchedGeometry
@@ -64,14 +67,16 @@ public enum GlassEffectTransitionBackport: Sendable {
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable)
 public typealias GlassEffectTransition = GlassEffectTransitionBackport
 
 @available(iOS, introduced: 13.0, obsoleted: 26.0)
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable, message: "Use universalGlassEffectTransition instead - Glass effect transitions are not available on visionOS")
 public extension View {
     @ViewBuilder
     func glassEffectTransition(

--- a/Sources/UniversalGlassBackports/BackportGlassEffect.swift
+++ b/Sources/UniversalGlassBackports/BackportGlassEffect.swift
@@ -8,7 +8,8 @@ import UniversalGlass
 @available(macOS, introduced: 11.0, obsoleted: 26.0)
 @available(macCatalyst, introduced: 13.0, obsoleted: 26.0)
 @available(tvOS, introduced: 18.0, obsoleted: 26.0)
-@available(watchOS, introduced: 11.0, obsoleted: 26.0)
+@available(watchOS, introduced: 10.0, obsoleted: 26.0)
+@available(visionOS, unavailable, message: "Use universalGlassEffect instead - Glass APIs are not available on visionOS")
 public extension View {
     func glassEffect() -> some View {
         universalGlassEffect()
@@ -31,6 +32,7 @@ public extension View {
 }
 
 #if DEBUG
+@available(iOS 17.0, macOS 14.0, tvOS 18.0, watchOS 10.0, *)
 #Preview("Backport Glass Effect") {
     VStack(spacing: 32) {
         Text("Standard Glass")


### PR DESCRIPTION
### Added

#### Configurable Fallback System
- **`.fallback(material:tint:)`** - New method on `UniversalGlassConfiguration` to customize fallback behavior on older OS versions
  - Override the default Material used when liquid glass is unavailable
  - Customize or remove the fallback tint color
  - Fully chainable with other configuration methods
  ```swift
  .universalGlassEffect(.regular.fallback(material: .thin, tint: .blue.opacity(0.2)))
  ```

#### Shadow Customization
- **`UniversalGlassShadow`** - New public struct for configuring shadow properties
  - `.default` - Subtle black blur (8pt radius, 0.04 opacity)
  - `.none` - No shadow
  - Custom shadows via `UniversalGlassShadow(color:radius:)` initializer
- **`.shadow(_:)`** - New method on `UniversalGlassConfiguration` to apply custom shadows to fallback rendering
  ```swift
  .universalGlassEffect(.regular.shadow(UniversalGlassShadow(color: .red, radius: 12)))
  ```

#### Per-Effect Transition Control
- **`.universalGlassTransition(_:)`** - New view modifier to override transitions for individual glass effects
  - Works with any `AnyTransition`
  - Allows per-effect customization instead of global defaults
  ```swift
  .universalGlassEffect()
  .universalGlassTransition(.slide)
  ```

#### Environment-Based Rendering Override
- **`.universalGlassRenderingMode(_:)`** - New environment modifier for global rendering control
  - Force all glass effects in a view hierarchy to use `.material`, `.glass`, or `.automatic`
  - Useful for testing fallback behavior, debugging, and creating preview variants
  ```swift
  MyApp().universalGlassRenderingMode(.material)
  ```

### Changed
- All configuration methods are now fully chainable, allowing complex customizations:
  ```swift
  .universalGlassEffect(
      .ultraThick
          .fallback(material: .thin, tint: .cyan.opacity(0.3))
          .shadow(UniversalGlassShadow(color: .blue, radius: 16))
          .tint(.purple)
          .interactive()
  )
  ```

### Documentation
- Updated wiki with comprehensive 1.0 feature documentation
- Added code examples for all new APIs
- Documented chaining behavior and use cases